### PR TITLE
Handle numbers

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -23,7 +23,7 @@ function getSizeBrutal(unit, element) {
 }
 
 function toPX(str, element) {
-  if (!str) return null
+  if (!str && str !== 0) return null
 
   element = element || document.body
   str = (str + '' || 'px').trim().toLowerCase()

--- a/browser.js
+++ b/browser.js
@@ -65,9 +65,14 @@ function toPX(str, element) {
 
   // detect number of units
   var parts = parseUnit(str)
-  if (!isNaN(parts[0]) && parts[1]) {
-    var px = toPX(parts[1], element)
-    return typeof px === 'number' ? parts[0] * px : null
+  if (!isNaN(parts[0])) {
+    if (parts[1]) {
+      var px = toPX(parts[1], element)
+      return typeof px === 'number' ? parts[0] * px : null
+    }
+    else {
+      return parts[0]
+    }
   }
 
   return null

--- a/index.js
+++ b/index.js
@@ -26,9 +26,14 @@ function toPX(str) {
 
   // detect number of units
   var parts = parseUnit(str)
-  if (!isNaN(parts[0]) && parts[1]) {
-    var px = toPX(parts[1])
-    return typeof px === 'number' ? parts[0] * px : null
+  if (!isNaN(parts[0])) {
+    if (parts[1]) {
+      var px = toPX(parts[1])
+      return typeof px === 'number' ? parts[0] * px : null
+    }
+    else {
+      return parts[0]
+    }
   }
 
   return null

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ var defaults = {
 }
 
 function toPX(str) {
-  if (!str) return null
+  if (!str && str !== 0) return null
 
   if (defaults[str]) return defaults[str]
 

--- a/test/index.js
+++ b/test/index.js
@@ -65,6 +65,8 @@ tape('edge cases', function (t) {
 
   t.equal(toPX('10'), 10, 'number no units')
   t.equal(toPX(10), 10, 'number value')
+  t.equal(toPX('0'), 0, 'number no units')
+  t.equal(toPX(0), 0, 'number value')
 
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -65,8 +65,8 @@ tape('edge cases', function (t) {
 
   t.equal(toPX('10'), 10, 'number no units')
   t.equal(toPX(10), 10, 'number value')
-  t.equal(toPX('0'), 0, 'number no units')
-  t.equal(toPX(0), 0, 'number value')
+  t.equal(toPX('0'), 0, 'zero no units')
+  t.equal(toPX(0), 0, 'zero value')
 
   t.end()
 })

--- a/test/index.js
+++ b/test/index.js
@@ -62,8 +62,9 @@ tape('edge cases', function (t) {
   t.equal(toPX(null), null, 'null value')
   t.equal(toPX('abc'), null, 'unknown units')
   t.equal(toPX('5def'), null, 'wrong units')
-  t.equal(toPX('10'), null, 'number no units')
-  t.equal(toPX(10), null, 'number value')
+
+  t.equal(toPX('10'), 10, 'number no units')
+  t.equal(toPX(10), 10, 'number value')
 
   t.end()
 })


### PR DESCRIPTION
Following the #4 - the test was wrong, numbers do not get parsed for now

```js
px(123) // null
```

This PR considers them direct px values.

```js
px(123) // 123
```

@mikolalysenko 